### PR TITLE
remove sync::subscribe

### DIFF
--- a/examples/sync.rs
+++ b/examples/sync.rs
@@ -1,16 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     detect();
-    subscribe();
     Ok(())
 }
 
 fn detect() {
     println!("Current mode: {:?}", dark_light::sync::detect());
-}
-
-fn subscribe() {
-    let stream = dark_light::sync::subscribe();
-    while let Ok(mode) = stream.recv() {
-        println!("System theme changed: {:?}", mode);
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,24 +76,4 @@ pub mod sync {
     /// }
     /// ```
     pub use super::platforms::platform::detect::sync::detect;
-
-    /// Notifies the user if the system theme has been changed.
-    ///
-    /// This function returns a stream of `Mode` values. The stream will emit a new value whenever the system theme changes.
-    ///
-    /// # Example
-    ///
-    /// ``` no_run
-    /// use dark_light::Mode;
-    ///
-    /// let stream = dark_light::sync::subscribe();
-    /// while let Ok(mode) = stream.recv() {
-    ///     match mode {
-    ///         Mode::Dark => {},
-    ///         Mode::Light => {},
-    ///         Mode::Default => {},
-    ///     }
-    /// }
-    /// ```
-    pub use super::platforms::platform::subscribe::sync::subscribe;
 }

--- a/src/platforms/freedesktop/subscribe.rs
+++ b/src/platforms/freedesktop/subscribe.rs
@@ -5,37 +5,6 @@ use futures_lite::{Stream, StreamExt};
 
 use crate::Mode;
 
-#[cfg(any(feature = "sync", doc))]
-pub(crate) mod sync {
-    use super::super::Mode;
-    use super::color_scheme_stream;
-    use futures_lite::StreamExt;
-
-    pub fn subscribe() -> std::sync::mpsc::Receiver<Mode> {
-        let (tx, rx) = std::sync::mpsc::channel();
-
-        std::thread::spawn(move || {
-            futures_lite::future::block_on(async {
-                let stream = match color_scheme_stream().await {
-                    Ok(stream) => stream.boxed(),
-                    Err(err) => {
-                        log::error!("Failed to subscribe to color scheme changes: {}", err);
-                        futures_lite::stream::empty().boxed()
-                    }
-                };
-
-                stream
-                    .for_each(|mode| {
-                        let _ = tx.send(mode);
-                    })
-                    .await;
-            });
-        });
-
-        rx
-    }
-}
-
 pub async fn subscribe() -> impl Stream<Item = Mode> + Send {
     match color_scheme_stream().await {
         Ok(stream) => stream.boxed(),

--- a/src/platforms/macos/subscribe.rs
+++ b/src/platforms/macos/subscribe.rs
@@ -1,28 +1,5 @@
 use crate::Mode;
 
-#[cfg(any(feature = "sync", doc))]
-pub(crate) mod sync {
-    pub fn subscribe() -> std::sync::mpsc::Receiver<crate::Mode> {
-        let (tx, rx) = std::sync::mpsc::channel();
-        let mut last_mode = crate::sync::detect();
-
-        tx.send(last_mode).unwrap();
-
-        std::thread::spawn(move || loop {
-            let current_mode = crate::sync::detect();
-
-            if current_mode != last_mode {
-                if tx.send(current_mode).is_err() {
-                    break;
-                }
-                last_mode = current_mode;
-            }
-        });
-
-        rx
-    }
-}
-
 pub async fn subscribe() -> impl futures_lite::Stream<Item = Mode> {
     Box::pin(futures_lite::stream::unfold(
         crate::detect().await,

--- a/src/platforms/websys/subscribe.rs
+++ b/src/platforms/websys/subscribe.rs
@@ -1,26 +1,3 @@
-#[cfg(any(feature = "sync", doc))]
-pub(crate) mod sync {
-    pub fn subscribe() -> std::sync::mpsc::Receiver<crate::Mode> {
-        let (tx, rx) = std::sync::mpsc::channel();
-        let mut last_mode = crate::sync::detect();
-
-        tx.send(last_mode).unwrap();
-
-        std::thread::spawn(move || loop {
-            let current_mode = crate::sync::detect();
-
-            if current_mode != last_mode {
-                if tx.send(current_mode).is_err() {
-                    break;
-                }
-                last_mode = current_mode;
-            }
-        });
-
-        rx
-    }
-}
-
 pub async fn subscribe() -> impl futures_lite::Stream<Item = crate::Mode> {
     Box::pin(futures_lite::stream::unfold(
         crate::detect().await,

--- a/src/platforms/windows/subscribe.rs
+++ b/src/platforms/windows/subscribe.rs
@@ -1,30 +1,5 @@
 use crate::Mode;
 
-#[cfg(any(feature = "sync", doc))]
-pub(crate) mod sync {
-    use crate::Mode;
-
-    pub fn subscribe() -> std::sync::mpsc::Receiver<Mode> {
-        let (tx, rx) = std::sync::mpsc::channel();
-        let mut last_mode = crate::sync::detect();
-
-        tx.send(last_mode).unwrap();
-
-        std::thread::spawn(move || loop {
-            let current_mode = crate::sync::detect();
-
-            if current_mode != last_mode {
-                if tx.send(current_mode).is_err() {
-                    break;
-                }
-                last_mode = current_mode;
-            }
-        });
-
-        rx
-    }
-}
-
 pub async fn subscribe() -> impl futures_lite::Stream<Item = Mode> {
     Box::pin(futures_lite::stream::unfold(
         crate::detect().await,


### PR DESCRIPTION
This is just wrapping async code and I don't think there's much of a use case for it. Anyone who wants this can start their own async executor and use the async fn subscribe.